### PR TITLE
fix: creating Orderly Key does not save private key to localStorage

### DIFF
--- a/src/Account.tsx
+++ b/src/Account.tsx
@@ -189,7 +189,7 @@ export const Account: FC<{
         disabled={!wallet || !connectedChain || !brokerId}
         onClick={async () => {
           if (!wallet || !connectedChain || !brokerId) return;
-          const key = await addOrderlyKey(wallet, connectedChain.id, brokerId, scope);
+          const key = await addOrderlyKey(wallet, connectedChain.id, brokerId, scope, accountId);
           setOrderlyKey(key);
         }}
       >

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -161,7 +161,8 @@ export async function addOrderlyKey(
   wallet: WalletState,
   chainId: string,
   brokerId: string,
-  scope: Scope
+  scope: Scope,
+  accountId: string
 ): Promise<Uint8Array> {
   const privateKey = utils.randomPrivateKey();
   const orderlyKey = `ed25519:${encodeBase58(await getPublicKeyAsync(privateKey))}`;
@@ -199,6 +200,10 @@ export async function addOrderlyKey(
   if (!keyJson.success) {
     throw new Error(keyJson.message);
   }
+  window.localStorage.setItem(
+    `${ORDERLY_KEY_LOCAL_STORAGE}:${accountId}`,
+    base64EncodeURL(privateKey)
+  );
   return privateKey;
 }
 


### PR DESCRIPTION
### Current
- Orderly keys are not saved to localStorage upon creation

### Fix
- save Orderly private key to localStorage
![image](https://github.com/user-attachments/assets/c9010bb7-726a-449d-bef9-b2e2fbb05fe4)
